### PR TITLE
Update GRPC_HEALTH_PROBE_VERSION and Fix random range

### DIFF
--- a/src/BeaverTripleService/Dockerfile
+++ b/src/BeaverTripleService/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go1.17.3.linux-amd64.tar.gz
 
 # grpcサーバのhealthcheckをするためのツールを
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.14 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 

--- a/src/BeaverTripleService/TripleGenerator/TripleGenerator.go
+++ b/src/BeaverTripleService/TripleGenerator/TripleGenerator.go
@@ -10,15 +10,17 @@ import (
 )
 
 var Db *ts.SafeTripleStore
-var randMax = int64(1 << 60)
-var randMin = int64(-1 << 60)
+var tripleRandMax = int64(1000)
+var tripleRandMin = int64(-1000)
+var sharizeRandMax = int64(1 << 60)
+var sharizeRandMin = int64(-1 << 60)
 
 func init() {
 	Db = ts.GetInstance()
 }
 
 func sharize(data int64, size uint32) ([]int64, error) {
-	shares, err := utils.GetRandInt64Slice(uint64(size-1), randMin, randMax)
+	shares, err := utils.GetRandInt64Slice(uint64(size-1), sharizeRandMin, sharizeRandMax)
 	if err != nil {
 		errText := "乱数取得に失敗"
 		logger.Error(errText)
@@ -38,7 +40,7 @@ func GenerateTriples(amount uint32) (map[uint32]([]*ts.Triple), error) {
 	ret := make(map[uint32]([]*ts.Triple))
 
 	for i := uint32(0); i < amount; i++ {
-		randInt64Slice, err := utils.GetRandInt64Slice(2, randMin, randMax)
+		randInt64Slice, err := utils.GetRandInt64Slice(2, tripleRandMin, tripleRandMax)
 		if err != nil {
 			errText := "乱数取得に失敗"
 			logger.Error(errText)


### PR DESCRIPTION
# Summary
Fix

# Purpose
- Make healthcheck work properly 
- Fix triple

# Contents
- Update GRPC_HEALTH_PROBE_VERSION to `0.4.14`
  - To use `-rpc-header` (>=[`0.4.4`](https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.4))
- Undo random range of triple

# Testing Methods Performed
- make debug on [QuickMPC](https://github.com/acompany-develop/QuickMPC/tree/14d585d69a91f97233bbf06a4733774881549ece)
